### PR TITLE
Add multi-target CPU wheel builds and update CI toolchains

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-26, macos-26-intel]
+        runner: [ubuntu-latest, ubuntu-24.04-arm, windows-2025-vs2026, macos-26, macos-26-intel]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -28,12 +28,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, windows-latest, macos-latest]
+        runner: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-26, macos-26-intel]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
+        env:
+          ADG_MULTIPLE_TARGET: "true"
+          CIBW_ENVIRONMENT_PASS_LINUX: ADG_MULTIPLE_TARGET
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.runner }}

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -3,13 +3,6 @@ name: Build release binaries
 on:
   workflow_call:
 
-permissions: {}
-
-env:
-  CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
-  CIBW_BEFORE_ALL_WINDOWS: rustup target add x86_64-pc-windows-gnu
-  CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
-
 jobs:
   sdist:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             ext: so
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            ext: so
           - os: windows-latest
             target: x86_64-pc-windows-gnu
             ext: dll
-          - os: macos-latest
+          - os: macos-26-intel
+            target: x86_64-apple-darwin
+            ext: dylib
+          - os: macos-26
             target: aarch64-apple-darwin
             ext: dylib
     runs-on: ${{ matrix.os }}

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -60,6 +60,9 @@ class CustomHook(BuildHookInterface[Any]):
         # Multiple target support
         if os.environ.get("ADG_MULTIPLE_TARGET", "").lower() in ["true", "1"] and target.cpus:
             print("Building multiple targets...", file=sys.stderr)
+
+            host_target_triple = get_host_target_triple()
+
             for cpu in target.cpus:
                 rust_flags = [f"-C target-cpu={cpu.name}"]
 
@@ -69,9 +72,13 @@ class CustomHook(BuildHookInterface[Any]):
                 env = os.environ.copy()
                 env["RUSTFLAGS"] = " ".join(rust_flags)
                 built_target_dir = Path(f"target/{cpu.name}")
-                subprocess.run(["cargo", "build", "--release", "--target-dir", built_target_dir], check=True, env=env)
+                subprocess.run(
+                    ["cargo", "build", "--release", "--target", host_target_triple, "--target-dir", built_target_dir],
+                    check=True,
+                    env=env,
+                )
 
-                built = built_target_dir / "release" / f"{target.prefix}{CRATE_NAME}{target.ext}"
+                built = built_target_dir / host_target_triple / "release" / f"{target.prefix}{CRATE_NAME}{target.ext}"
                 shutil.copy2(built, self.target_dir / Path(built.name).with_suffix(cpu.suffix + built.suffix))
 
             # Write a manifest to ensure instruction set-based loading works as desired
@@ -89,3 +96,12 @@ class CustomHook(BuildHookInterface[Any]):
 
     def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str) -> None:
         shutil.rmtree(self.target_dir, ignore_errors=True)
+
+
+def get_host_target_triple() -> str:
+    """Query rustc for the host target triple (e.g. x86_64-unknown-linux-gnu)."""
+    result = subprocess.run(["rustc", "-vV"], capture_output=True, text=True, check=True)
+    for line in result.stdout.splitlines():
+        if line.startswith("host:"):
+            return line.split(":", 1)[1].strip()
+    raise RuntimeError("Could not determine host target triple from `rustc -vV`")

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,27 +1,47 @@
-# This entire file is copied from https://github.com/sgt0/vapoursynth-hysteresis/hatch_build.py
 from __future__ import annotations
 
+import os
 import platform
 import shutil
 import subprocess
+import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from packaging import tags
 
-# Map OS to the shared library extension.
-LIB_EXTENSIONS = {
-    "Linux": "so",
-    "Windows": "dll",
-    "Darwin": "dylib",
-}
+CRATE_NAME = "adaptivegrain_rs"
 
-# Map OS to the shared library prefix.
-LIB_PREFIXES = {
-    "Linux": "lib",
-    "Windows": "",
-    "Darwin": "lib",
+
+class CPU(NamedTuple):
+    name: str
+    suffix: str
+    disable: str = ""
+
+
+class Target(NamedTuple):
+    prefix: str
+    ext: str
+    cpus: list[CPU] | None = None
+
+
+x86_64_CPUS = [
+    CPU("x86-64", ""),
+    CPU("haswell", ".avx2"),
+    CPU("znver4", ".zn4", disable="sse4a"),
+]
+
+TARGETS = {
+    "linux": {
+        "x86_64": Target("lib", ".so", x86_64_CPUS),
+        "aarch64": Target("lib", ".so"),
+    },
+    "windows": {"amd64": Target("", ".dll", x86_64_CPUS)},
+    "darwin": {
+        "x86_64": Target("lib", ".dylib", x86_64_CPUS[:-1]),
+        "arm64": Target("lib", ".dylib"),
+    },
 }
 
 
@@ -32,23 +52,40 @@ class CustomHook(BuildHookInterface[Any]):
         build_data["pure_python"] = False
         build_data["tag"] = f"py3-none-{next(tags.platform_tags())}"
 
-        os_name = platform.system()
-        arch = platform.machine()
-        ext = LIB_EXTENSIONS[os_name]
-        prefix = LIB_PREFIXES[os_name]
-        crate_name = "adaptivegrain"
-        lib_filename = f"{prefix}{crate_name}_rs.{ext}"
+        uname = platform.uname()
+        target = TARGETS[uname.system.lower()][uname.machine.lower()]
 
         self.target_dir.mkdir(parents=True, exist_ok=True)
 
-        env = dict(__import__("os").environ)
-        env["RUSTFLAGS"] = f"-C target-cpu=haswell"
+        # Multiple target support
+        if os.environ.get("ADG_MULTIPLE_TARGET", "").lower() in ["true", "1"] and target.cpus:
+            print("Building multiple targets...", file=sys.stderr)
+            for cpu in target.cpus:
+                rust_flags = [f"-C target-cpu={cpu.name}"]
 
-        cmd = ["cargo", "build", "--release"]
+                if cpu.disable:
+                    rust_flags.append(f" -C target-feature=-{cpu.disable}")
 
-        subprocess.run(cmd, check=True, env=env)
-        built = Path("target") / "release" / lib_filename
-        shutil.copy2(built, self.target_dir / lib_filename)
+                env = os.environ.copy()
+                env["RUSTFLAGS"] = " ".join(rust_flags)
+                built_target_dir = Path(f"target/{cpu.name}")
+                subprocess.run(["cargo", "build", "--release", "--target-dir", built_target_dir], check=True, env=env)
+
+                built = built_target_dir / "release" / f"{target.prefix}{CRATE_NAME}{target.ext}"
+                shutil.copy2(built, self.target_dir / Path(built.name).with_suffix(cpu.suffix + built.suffix))
+
+            # Write a manifest to ensure instruction set-based loading works as desired
+            # https://github.com/vapoursynth/vapoursynth/discussions/1196
+            (self.target_dir / "manifest.vs").write_text(f"[VapourSynth Manifest V1]\n{target.prefix}{CRATE_NAME}\n")
+        else:
+            # Build for *this* machine
+            env = os.environ.copy()
+            env["RUSTFLAGS"] = "-C target-cpu=native"
+
+            subprocess.run(["cargo", "build", "--release"], env=env)
+
+            built = Path("target") / "release" / f"{target.prefix}{CRATE_NAME}{target.ext}"
+            shutil.copy2(built, self.target_dir)
 
     def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str) -> None:
-        shutil.rmtree(self.target_dir.parent, ignore_errors=True)
+        shutil.rmtree(self.target_dir, ignore_errors=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,15 @@ before-all = "rustup target add x86_64-pc-windows-gnu"
 # VapourSynth's minimum macOS target is 13.0.
 MACOSX_DEPLOYMENT_TARGET = "13.0"
 
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_x86_64"
+inherit.before-all = "append"
+inherit.environment = "append"
+before-all = [
+    "dnf install -y gcc-toolset-12",
+    "source /opt/rh/gcc-toolset-12/enable",
+]
+environment.PATH = "/opt/rh/gcc-toolset-12/root/usr/bin:$PATH"
+
 [project.urls]
 Homepage = "https://github.com/kageru/adaptivegrain"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,16 @@ skip = [
     "*-musllinux_x86_64", # musllinux 64-bit does not support cdylib.
 ]
 
+[tool.cibuildwheel.linux]
+before-all = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
+environment = "PATH=$HOME/.cargo/bin:$PATH"
+
+[tool.cibuildwheel.windows]
+before-all = "rustup target add x86_64-pc-windows-gnu"
+
 [tool.cibuildwheel.macos.environment]
-# Rust's minimum macOS target is 10.12.
-MACOSX_DEPLOYMENT_TARGET = "10.12"
+# VapourSynth's minimum macOS target is 13.0.
+MACOSX_DEPLOYMENT_TARGET = "13.0"
 
 [project.urls]
 Homepage = "https://github.com/kageru/adaptivegrain"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ repair-wheel-command = "auditwheel repair --strip -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
-before-all = "rustup target add x86_64-pc-windows-gnu"
+before-all = "rustup target add x86_64-pc-windows-msvc"
 
 [tool.cibuildwheel.macos.environment]
 # VapourSynth's minimum macOS target is 13.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,18 @@ artifacts = [
 path = "hatch_build.py"
 
 [tool.cibuildwheel]
-skip = [
-    "*-musllinux_i686",   # Rust does not provide Cargo for musllinux 32-bit.
-    "*-musllinux_x86_64", # musllinux 64-bit does not support cdylib.
-]
+build-frontend = "build[uv]"
+build = "cp312-*"
+# Rust does not provide Cargo for musllinux 32-bit and 64-bit does not support cdylib.
+skip = ["*-musllinux*"]
 
 [tool.cibuildwheel.linux]
 before-all = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
 environment = "PATH=$HOME/.cargo/bin:$PATH"
+repair-wheel-command = "auditwheel repair --strip -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows]
+archs = ["AMD64"]
 before-all = "rustup target add x86_64-pc-windows-gnu"
 
 [tool.cibuildwheel.macos.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 license = "MIT"
 license-files = ["LICENSE.md"]
 
-dependencies = ["vapoursynth>=74"]
+dependencies = ["vapoursynth>=75"]
 
 [build-system]
 requires = ["hatchling==1.29.0", "packaging==26.2"]


### PR DESCRIPTION
VapourSynth R75 added support for multiple versions compiled for different CPU instruction set levels.

This PR updates the package build and CI pipeline to produce optimized VapourSynth plugin binaries across supported Linux, 
Windows, and macOS targets.

- Moves cibuildwheel configuration into pyproject.toml so builds can be easily performed using the cibuildwheel CLI.
- Adds multi-CPU Rust builds for x86_64 platforms
- Add back the fixed VapourSynth manifest for runtime binary selection
- Expands release/CI coverage to ARM and Intel runners.
- Updates Windows/macOS build environments.